### PR TITLE
Create masonry-horizontal.js

### DIFF
--- a/masonry-horizontal.js
+++ b/masonry-horizontal.js
@@ -13,7 +13,7 @@
     // AMD
     define( [
         'get-size/get-size',
-        'isotope/js/layout-mode'
+        'isotope-layout/js/layout-mode'
       ],
       factory );
   } else if ( typeof module == 'object' && module.exports ) {


### PR DESCRIPTION
Fix error "Module not found: Error: Can't resolve 'isotope/js/layout-mode'" when importing a module into ES6